### PR TITLE
Update Gradio event API for Hugging Face Space

### DIFF
--- a/app.py
+++ b/app.py
@@ -159,11 +159,17 @@ def create_interface():
             outputs=[status_output, progress_output, sample_image, sample_info]
         )
         
-        # Auto-refresh every 30 seconds
+        # Run once on load
         interface.load(
             fn=refresh_all,
-            outputs=[status_output, progress_output, sample_image, sample_info],
-            every=30
+            outputs=[status_output, progress_output, sample_image, sample_info]
+        )
+
+        # Auto-refresh every 30 seconds (Gradio 4+ API)
+        auto_timer = gr.Timer(interval=30.0)
+        auto_timer.tick(
+            fn=refresh_all,
+            outputs=[status_output, progress_output, sample_image, sample_info]
         )
     
     return interface

--- a/app.py
+++ b/app.py
@@ -182,13 +182,15 @@ def main():
     setup_result = setup_environment()
     print(setup_result)
     
-    # Create and launch interface
-    interface = create_interface()
-    interface.launch(
+    # Launch interface
+    demo.launch(
         server_name="0.0.0.0",
         server_port=7860,
         share=False
     )
+
+# Expose Gradio app for Hugging Face Spaces
+demo = create_interface()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Update Gradio event API to replace deprecated `every` argument with `gr.Timer` for periodic refresh.

The `every` keyword argument was removed from `interface.load` in Gradio 4, causing a `TypeError`. This change adapts the periodic refresh mechanism to the new `gr.Timer().tick()` pattern, while retaining an initial `interface.load()` for page initialization.

---
<a href="https://cursor.com/background-agent?bcId=bc-4b416a91-9e1b-4ee8-be1c-33236e1a9826">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4b416a91-9e1b-4ee8-be1c-33236e1a9826">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

